### PR TITLE
feat: replace warn messages and add history

### DIFF
--- a/src/modules/mentorships.py
+++ b/src/modules/mentorships.py
@@ -7,7 +7,6 @@ import os
 import logging
 
 import discord
-from discord import message
 from discord.embeds import Embed
 from discord.ext.commands import Cog, group, MissingRequiredArgument
 from discord.ext.commands.core import has_any_role
@@ -113,49 +112,97 @@ Uso:
 
     @mentee.command()
     @has_any_role('admin-mentors', 'Mentors')
-    async def warn(self, ctx, user):
-        def db_add(self, id, warned_user, warns_quantity):
+    async def warn(self, ctx, user, *reason):
+        def db_add(self, id, warned_user, warns_quantity, history):
             self.db.create('Mentorship_Warns', {
                 "id": id,
                 "warned_user": str(warned_user),
-                "warns_quantity": warns_quantity
+                "warns_quantity": warns_quantity,
+                "history": history,
             })
         '''
         Comando mentee warn
         '''
+
+        reason = " ".join(reason)
+        now = datetime.now()
+        history_content = {
+            "timestamp": now.strftime("%d/%m/%Y %H:%M:%S"),
+            "reason": reason
+        }
+
         try:
             await ctx.message.delete()
             userId = user[3:-1]
             member = await ctx.guild.fetch_member(userId)
             mentee = self.db.get_mentee_by_discord_id(userId)
+            history = mentee['data']['history']
+
+            # if the field doesn't exist, I add it
+            if history is None:
+                history = [history_content]
+            else:
+                history.append(history_content)
+
             self.db.update_with_ref(
                 mentee['ref'],
                 {
                     "warns_quantity": mentee['data']['warns_quantity'] + 1,
+                    "history": history,
                 }
             )
 
             # Send warn message
-            embed = Embed(title=f"{member.display_name} ha sido penalizado/a",
-                          description=f"Cantidad de penalizaciones: {mentee['data']['warns_quantity'] + 1}", color=0xFF6B00)
-            embed.add_field(name="ID del usuario",
-                            value=userId, inline=True)
-            embed.set_footer(
-                text=ctx.author, icon_url=ctx.author.avatar_url)
-            await ctx.send(embed=embed)
+            message = f"""
+**{member.mention} ha sido penalizado/a**
+Cantidad de penalizaciones: **{mentee['data']['warns_quantity'] + 1}**
+**Motivo**
+{reason}
+**Fecha**
+{now.strftime("%d/%m/%Y %H:%M:%S")}
+**ID del usuario**
+{userId}
+
+`{ctx.author}`
+"""
+            await ctx.channel.send(message)
+
+            # embed = Embed(title=f"{member.display_name} ha sido penalizado/a",
+            #               description=f"Cantidad de penalizaciones: {mentee['data']['warns_quantity'] + 1}", color=0xFF6B00)
+            # embed.add_field(name="ID del usuario",
+            #                 value=userId, inline=True)
+            # embed.set_footer(
+            #     text=ctx.author, icon_url=ctx.author.avatar_url)
+            # await ctx.send(embed=embed)
 
         except Exception as e:
             if type(e) is faunadb.errors.NotFound:
-                db_add(self, str(member.id),
-                       member.display_name, 1)
+                history = [history_content]
+                db_add(self, str(member.id), member.display_name, 1, history)
+
                 # Send warn message
-                embed = discord.Embed(title=f"{member.display_name} ha sido penalizado/a",
-                                      description="Cantidad de penalizaciones: 1", color=0xFF6B00)
-                embed.add_field(name="ID del usuario",
-                                value=userId, inline=True)
-                embed.set_footer(
-                    text=ctx.author, icon_url=ctx.author.avatar_url)
-                await ctx.send(embed=embed)
+                message = f"""
+**{member.mention} ha sido penalizado/a**
+Cantidad de penalizaciones: **1**
+**Motivo**
+{reason}
+**Fecha**
+{now.strftime("%d/%m/%Y %H:%M:%S")}
+**ID del usuario**
+{userId}
+
+`{ctx.author}`
+"""
+
+                await ctx.channel.send(message)
+
+                # embed = discord.Embed(title=f"{member.display_name} ha sido penalizado/a",
+                #                       description="Cantidad de penalizaciones: 1", color=0xFF6B00)
+                # embed.add_field(name="ID del usuario",
+                #                 value=userId, inline=True)
+                # embed.set_footer(
+                #     text=ctx.author, icon_url=ctx.author.avatar_url)
+                # await ctx.send(embed=embed)
             else:
                 print(e)
 


### PR DESCRIPTION
- Replace embeds by normal messages.
- Add reason and date in the messages.
- Add history with timestamp and reason in the database.