### PR TITLE
Use id instead of role names

### DIFF
--- a/src/modules/mentorships.py
+++ b/src/modules/mentorships.py
@@ -41,10 +41,16 @@ class Mentorship(Cog):
         valid = re.fullmatch(regex, user)
         return valid
 
+    admin_mentor_role_id = 875764700418297868
+    mentors_role_id = 645409801844555787
+    staff_role_id = 936626779798507601
+    admins_role_id = 645411178398351363
+
     # >mentee
     #! Comando mentee
+
     @group(invoke_without_command=True)
-    @has_any_role('admin-mentors', 'Mentors')
+    @has_any_role(admin_mentor_role_id, mentors_role_id)
     async def mentee(self, ctx, user, time=None, channel=None):
         '''
         Comando mentee
@@ -94,7 +100,7 @@ class Mentorship(Cog):
             raise error
 
     @mentee.command()
-    @has_any_role('Mentors', 'admin-mentors')
+    @has_any_role(admin_mentor_role_id, mentors_role_id)
     async def help(self, ctx):
         """Imprimo embed con los comandos de `mentee`"""
         PREFIX = self.PREFIX
@@ -130,12 +136,12 @@ class Mentorship(Cog):
     async def mentee_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Mentors/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Mentors/Admin-Mentors", delete_after=30)
         else:
             raise error
 
     @mentee.command()
-    @has_any_role('admin-mentors', 'Mentors')
+    @has_any_role(admin_mentor_role_id, mentors_role_id)
     async def warn(self, ctx, user, *reason):
         if self.validateDiscordUser(user):
             userId = int(re.search(r'\d+', user).group())
@@ -223,7 +229,7 @@ class Mentorship(Cog):
     async def mentee_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Mentors/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Mentors/Admin-Mentors", delete_after=30)
         elif isinstance(error, MissingRequiredArgument):
             await ctx.message.delete()
             await ctx.channel.send("Por favor, etiquetar al usuario al que desea dar una advertencia.", delete_after=30)
@@ -231,7 +237,7 @@ class Mentorship(Cog):
             raise error
 
     @mentee.command()
-    @has_any_role('Staff', 'admin-mentors')
+    @has_any_role(staff_role_id, admin_mentor_role_id)
     async def warn_rm(self, ctx, user):
         '''
         Comando mentee warn remove
@@ -291,7 +297,7 @@ class Mentorship(Cog):
     async def mentee_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Staff/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Staff/Admin-Mentors", delete_after=30)
         elif isinstance(error, MissingRequiredArgument):
             await ctx.message.delete()
             await ctx.channel.send("Por favor, etiquetar al usuario al que desea quitar una penalización.", delete_after=30)
@@ -299,7 +305,7 @@ class Mentorship(Cog):
             raise error
 
     @mentee.command()
-    @has_any_role('Staff', 'admin-mentors')
+    @has_any_role(staff_role_id, admin_mentor_role_id)
     async def warn_ls(self, ctx):
         '''
         Comando mentee warn list
@@ -323,12 +329,12 @@ class Mentorship(Cog):
     async def mentee_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Staff/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Staff/Admin-Mentors", delete_after=30)
         else:
             raise error
 
     @mentee.command()
-    @has_any_role('admin-mentors', 'Mentors')
+    @has_any_role(admin_mentor_role_id, mentors_role_id)
     async def check(self, ctx, user):
         '''
         Comando mentee check
@@ -364,7 +370,7 @@ class Mentorship(Cog):
     async def mentee_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Mentors/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Mentors/Admin-Mentors", delete_after=30)
         elif isinstance(error, MissingRequiredArgument):
             await ctx.message.delete()
             await ctx.channel.send("Por favor, etiquetar el usuario que desea consultar.", delete_after=30)
@@ -372,7 +378,7 @@ class Mentorship(Cog):
             raise error
 
     @mentee.command()
-    @has_any_role('admin-mentors', 'Mentors')
+    @has_any_role(admin_mentor_role_id, mentors_role_id)
     async def add(self, ctx, user):
         '''
         Comando mentee add
@@ -407,7 +413,7 @@ class Mentorship(Cog):
 
             if mentee['data']['warns_quantity'] > 0:
                 adminMentorsRole = discord.utils.get(
-                    ctx.guild.roles, name="admin-mentors")
+                    ctx.guild.roles, id=self.admin_mentor_role_id)
                 # Send message
                 message = f"""
 > :no_entry:  **Solicitud de mentoría rechazada**
@@ -436,7 +442,7 @@ class Mentorship(Cog):
     async def add_error(self, ctx, error):
         if isinstance(error, MissingAnyRole):
             await ctx.message.delete()
-            await ctx.channel.send("No tienes el rol Mentors/admin-mentors", delete_after=30)
+            await ctx.channel.send("No tienes el rol Mentors/Admin-Mentors", delete_after=30)
         elif isinstance(error, MissingRequiredArgument):
             await ctx.message.delete()
             await ctx.channel.send("Por favor, etiquetar el usuario al que desea registrar para una mentoría.", delete_after=30)


### PR DESCRIPTION
Some mentoring roles were renamed, so this PR fixes that, instead of using the roles by name, it now uses the role id